### PR TITLE
Undefined Subscription in processKeysForClient

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -339,10 +339,15 @@ function processKeysForClient (all, that) {
   var keys = Object.keys(all)
   var key = ''
   var decoded = null
+  var raw = null
 
   for (var i = 0; i < keys.length; i++) {
     key = keys[i]
-    decoded = msgpack.decode(that[key])
+    raw = that[key]
+    if (!raw) {
+      continue
+    }
+    decoded = msgpack.decode(raw)
     decoded.clientId = key
 
     that._matcher.add(decoded.topic, decoded)


### PR DESCRIPTION
this fixes a bug introduced in 2.6.x where processKeysForClient is trying to decode an `undefined` value. it's possible this could be a symptom of a different bug, so it might need a deeper look by @GavinDmello since i'm not as familiar with recent changes. the bug seems to be related to disconnected clients that have entries in `sub:client:`.

```
TypeError: Cannot read property 'length' of undefined
    at uint8 (/home/todd/aedes-persistence-redis/node_modules/msgpack-lite/lib/read-format.js:104:31)
    at Codec.decode (/home/todd/aedes-persistence-redis/node_modules/msgpack-lite/lib/read-core.js:13:16)
    at DecodeBuffer.fetch (/home/todd/aedes-persistence-redis/node_modules/msgpack-lite/lib/decode-buffer.js:54:21)
    at DecodeBuffer.read (/home/todd/aedes-persistence-redis/node_modules/msgpack-lite/lib/decode-buffer.js:39:28)
    at Object.decode (/home/todd/aedes-persistence-redis/node_modules/msgpack-lite/lib/decode.js:10:18)
    at processKeysForClient (/home/todd/aedes-persistence-redis/persistence.js:345:23)
    at BulkTransform.processKeys (/home/todd/aedes-persistence-redis/persistence.js:323:5)
    at emitOne (events.js:96:13)
    at BulkTransform.emit (events.js:188:7)
    at readableAddChunk (/home/todd/aedes-persistence-redis/node_modules/readable-stream/lib/_stream_readable.js:198:18)
    at BulkTransform.Readable.push (/home/todd/aedes-persistence-redis/node_modules/readable-stream/lib/_stream_readable.js:157:10)
    at afterTransform (/home/todd/aedes-persistence-redis/node_modules/throughv/throughv.js:33:14)
    at BulkTransformState.afterTransform (/home/todd/aedes-persistence-redis/node_modules/throughv/throughv.js:9:12)
    at ResultsHolder.release (/home/todd/aedes-persistence-redis/node_modules/fastparallel/parallel.js:182:12)
    at SingleCaller.release (/home/todd/aedes-persistence-redis/node_modules/fastparallel/parallel.js:157:17)
    at tryCatcher (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.successAdapter [as _fulfillmentHandler0] (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/nodeify.js:23:30)
    at Promise._settlePromise (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/promise.js:564:21)
    at Promise._settlePromise0 (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/home/todd/aedes-persistence-redis/node_modules/bluebird/js/release/async.js:143:10)
```