### PR TITLE
List reference for outgoing messages

### DIFF
--- a/lib/range.js
+++ b/lib/range.js
@@ -28,24 +28,12 @@ function handlePacket (err, res, self) {
     self.emit('error', err)
     return
   }
-  console.log('========', res)
+
   if (res.length) {
     self.results = res
   } else {
     self.results = null
   }
-
-  // if (res !== '{}') {
-  //   var results = parse(res)
-
-  //   if (results.err) {
-  //     self.emit('error', results.err)
-  //     return
-  //   }
-  //   self.results = results.value
-  // } else {
-  //   self.results = null
-  // }
 
   self.emit('ready')
 }

--- a/lib/range.js
+++ b/lib/range.js
@@ -1,0 +1,64 @@
+'use strict'
+
+var Readable = require('stream').Readable
+var util = require('util')
+
+function RangeStream (opt) {
+  Readable.call(this, opt)
+
+  this.opt = opt
+  this.opt.count = this.opt.count || 10
+  this.results = false
+
+  this.range()
+}
+
+util.inherits(RangeStream, Readable)
+
+RangeStream.prototype.range = function () {
+  var self = this
+
+  this.opt.redis.lrange(this.opt.key, 0, 10000, function lrangeResult (err, results) {
+    handlePacket(err, results, self)
+  })
+}
+
+function handlePacket (err, res, self) {
+  if (err) {
+    self.emit('error', err)
+    return
+  }
+  console.log('========', res)
+  if (res.length) {
+    self.results = res
+  } else {
+    self.results = null
+  }
+
+  // if (res !== '{}') {
+  //   var results = parse(res)
+
+  //   if (results.err) {
+  //     self.emit('error', results.err)
+  //     return
+  //   }
+  //   self.results = results.value
+  // } else {
+  //   self.results = null
+  // }
+
+  self.emit('ready')
+}
+
+RangeStream.prototype._read = function () {
+  if (this.results === false) {
+    return this.once('ready', this._read)
+  }
+
+  var results = this.results
+  this.results = null
+
+  this.push(results)
+}
+
+module.exports = RangeStream

--- a/persistence.js
+++ b/persistence.js
@@ -360,19 +360,23 @@ function processKeysForClient (all, that) {
 }
 
 RedisPersistence.prototype.outgoingEnqueue = function (sub, packet, cb) {
-  var key = 'outgoing:' + sub.clientId + ':' + packet.brokerId + ':' + packet.brokerCounter
-  this._getPipeline().set(key, msgpack.encode(new Packet(packet)), cb)
+  var listKey = 'outgoing:' + sub.clientId
+  var key = listKey + ':' + packet.brokerId + ':' + packet.brokerCounter
+
+  var multi = this._db.multi()
+  multi.set(key, msgpack.encode(new Packet(packet)))
+  multi.rpush(listKey, key)
+
+  multi.exec(cb)
 }
 
 function updateWithClientData (that, client, packet, cb) {
   var prekey = 'outgoing:' + client.id + ':' + packet.brokerId + ':' + packet.brokerCounter
-  var listKey = 'outgoing-id:' + client.id
   var postkey = 'outgoing-id:' + client.id + ':' + packet.messageId
 
   var multi = that._db.multi()
   multi.set(postkey, msgpack.encode(packet))
   multi.set(prekey, msgpack.encode(packet))
-  multi.rpush(listKey, postkey)
 
   multi.exec(function execMulti (err, results) {
     if (err) { return cb(err, client, packet) }
@@ -418,8 +422,9 @@ RedisPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
 
 RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb) {
   var that = this
-  var listKey = 'outgoing-id:' + client.id
+  var listKey = 'outgoing:' + client.id
   var key = 'outgoing-id:' + client.id + ':' + packet.messageId
+
   this._getPipeline().getBuffer(key, function clearMessageId (err, buf) {
     if (err) {
       return cb(err)
@@ -430,12 +435,12 @@ RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb
     }
 
     var packet = msgpack.decode(buf)
-    var prekey = 'outgoing:' + client.id + ':' + packet.brokerId + ':' + packet.brokerCounter
+    var prekey = listKey + ':' + packet.brokerId + ':' + packet.brokerCounter
 
     var multi = that._db.multi()
     multi.del(key)
     multi.del(prekey)
-    multi.lrem(listKey, 1, key)
+    multi.lrem(listKey, 1, prekey)
 
     multi.exec(function execOps (err) {
       cb(err, packet)
@@ -454,7 +459,7 @@ RedisPersistence.prototype.outgoingStream = function (client) {
   return new RangeStream({
     objectMode: true,
     redis: this._db,
-    key: 'outgoing-id:' + client.id
+    key: 'outgoing:' + client.id
   }).pipe(through.obj(split))
     .pipe(throughv.obj(this._decodeAndAugment))
 }


### PR DESCRIPTION
We have an issue on Aedes about the messages being delivered in some random order(due to scan). I just wrote a quick mosca like implementation for the outgoing messages. 
Also we have two sets of keys right now, the enqueued keys and the keys with the updated messageIds. Not sure which ones should be present in the list ref.
Is this the right approach ? 
The test cases are failing of course.
