### PR TITLE
Reimplementation of offline subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ aedesPersistenceRedis({
   host: '127.0.0.1',   // Redis host
   family: 4,           // 4 (IPv4) or 6 (IPv6)
   password: 'auth',
-  db: 0
+  db: 0,
+  maxSessionDelivery: 100 // maximum offline messages deliverable on client CONNECT, default is 1000
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tape": "^4.2.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^3.0.0",
+    "aedes-cached-persistence": "^4.0.0",
     "from2": "^2.3.0",
     "ioredis": "^3.0.0",
     "msgpack-lite": "^0.1.20",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "aedes-cached-persistence": "^3.0.0",
+    "from2": "^2.3.0",
     "ioredis": "^3.0.0",
     "msgpack-lite": "^0.1.20",
     "process-nextick-args": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "from2": "^2.3.0",
     "ioredis": "^3.0.0",
     "msgpack-lite": "^0.1.20",
-    "process-nextick-args": "^1.0.6",
     "pump": "^1.0.1",
     "qlobber": "^0.7.0",
     "through2": "^2.0.0",

--- a/persistence.js
+++ b/persistence.js
@@ -166,7 +166,7 @@ RedisPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
     count++
   }
 
-  pipeline.srem(subsKey, subs)
+  pipeline.srem(subsKey, subs) // TODO matcher.match should be checked
 
   pipeline.hdel(clientSubKey, subs)
 
@@ -275,12 +275,13 @@ RedisPersistence.prototype._setup = function () {
   }
 
   var that = this
+  var pipeline = that._getPipeline()
 
   var splitStream = through.obj(split)
 
   var hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
-    var pipeline = that._getPipeline()
-    pipeline.hgetall(clientId, function clientHash (err, hash) {
+    var clientSubKey = clientKey + clientId
+    pipeline.hgetall(clientSubKey, function clientHash (err, hash) {
       cb(err, {clientHash: hash, clientId: clientId})
     })
   }, function emitReady (cb) {

--- a/persistence.js
+++ b/persistence.js
@@ -76,10 +76,13 @@ RedisPersistence.prototype.storeRetained = function (packet, cb) {
   }
 }
 
-RedisPersistence.prototype.createRetainedStream = function (pattern) {
+RedisPersistence.prototype.createRetainedStreamCombi = function (patterns) {
   var that = this
   var qlobber = new Qlobber(qlobberOpts)
-  qlobber.add(pattern, true)
+
+  patterns.map(function (pattern) {
+    qlobber.add(pattern, true)
+  })
 
   var stream = through.obj(that._getChunk)
 
@@ -92,6 +95,10 @@ RedisPersistence.prototype.createRetainedStream = function (pattern) {
   })
 
   return pump(stream, throughv.obj(decodeRetainedPacket))
+}
+
+RedisPersistence.prototype.createRetainedStream = function (pattern) {
+  return this.createRetainedStreamCombi([pattern])
 }
 
 function matchRetained (stream, keys, qlobber) {

--- a/persistence.js
+++ b/persistence.js
@@ -275,11 +275,11 @@ RedisPersistence.prototype._setup = function () {
   }
 
   var that = this
-  var pipeline = that._getPipeline()
 
   var splitStream = through.obj(split)
 
   var hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
+    var pipeline = that._getPipeline()
     var clientSubKey = clientKey + clientId
     pipeline.hgetall(clientSubKey, function clientHash (err, hash) {
       cb(err, {clientHash: hash, clientId: clientId})

--- a/persistence.js
+++ b/persistence.js
@@ -105,12 +105,6 @@ function decodeRetainedPacket (chunk, enc, cb) {
   cb(null, msgpack.decode(chunk))
 }
 
-// function Sub (clientId, topic, qos) {
-//   this.clientId = clientId
-//   this.topic = topic
-//   this.qos = qos
-// }
-
 RedisPersistence.prototype.addSubscriptions = function (client, subs, cb) {
   if (!this.ready) {
     this.once('ready', this.addSubscriptions.bind(this, client, subs, cb))

--- a/persistence.js
+++ b/persistence.js
@@ -474,10 +474,10 @@ RedisPersistence.prototype.delWill = function (client, cb) {
     if (packet) {
       result = msgpack.decode(packet)
     }
-  })
 
-  that._db.del(key, function deleteWill (err) {
-    cb(err, result, client)
+    that._db.del(key, function deleteWill (err) {
+      cb(err, result, client)
+    })
   })
 }
 

--- a/persistence.js
+++ b/persistence.js
@@ -119,7 +119,6 @@ RedisPersistence.prototype.addSubscriptions = function (client, subs, cb) {
     if (sub.qos > 0) {
       offlines.push(sub.topic)
       count++
-      // TODO don't wait the client an extra tick
       this._waitFor(client, sub.topic, finish)
     }
   }


### PR DESCRIPTION
- dropped `counter:offline:subscriptions` key. offline subs are SCARD of `subs` SET 
- dropped `counter:offline:clients` key. offline clients are SCARD of `clients` SET
- dropped `sub:client`, no subscriptions index of clientIds are stored any more. all subscription list api methods are implemented VIA internal Qlobber.
- renamed `client:sub:` to `client:`
- new `clients` SET added containing all client ids
- new `subs` SET added containing all topics
- all redis operations are handled by `_getPipeline`

Would you please review these @mcollina @GavinDmello ?