### PR TITLE
Re-implementation for QOS=1 & QOS=2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "aedes-cached-persistence": "^4.0.0",
+    "fastq": "^1.5.0",
     "from2": "^2.3.0",
     "ioredis": "^3.0.0",
     "msgpack-lite": "^0.1.20",

--- a/persistence.js
+++ b/persistence.js
@@ -406,8 +406,6 @@ RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb
   var that = this
   var listKey = 'outgoing:' + client.id
   var key = 'outgoing-id:' + client.id + ':' + packet.messageId
-  var packetKey = 'packet:' + packet.brokerId + ':' + packet.brokerCounter
-  var countKey = 'expected:' + packet.brokerId + ':' + packet.brokerCounter
 
   var clientKey = this.msgMap[key]
   this.msgMap[key] = null
@@ -428,6 +426,10 @@ RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb
     var origPacket = msgpack.decode(buf)
     // origPacket.messageId = packet.messageId
     that._db.del(clientKey, finish)
+
+    var packetKey = 'packet:' + origPacket.brokerId + ':' + origPacket.brokerCounter
+    var countKey = 'expected:' + origPacket.brokerId + ':' + origPacket.brokerCounter
+
     that._db.lrem(listKey, 0, packetKey, finish)
     that._db.decr(countKey, function (err, remained) {
       if (err) {

--- a/persistence.js
+++ b/persistence.js
@@ -436,6 +436,8 @@ RedisPersistence.prototype.outgoingClearMessageId = function (client, packet, cb
       }
       if (remained === 0) {
         that._db.del(packetKey, finish)
+      } else {
+        finish()
       }
     })
 


### PR DESCRIPTION
Changes made regarding https://github.com/mcollina/aedes-persistence-redis/issues/35 & https://github.com/mcollina/aedes-cached-persistence/issues/5 

1. new API `aedes-persistence#outgoingEnqueue(subs, packet, cb)` with default implementation in aedes-cached-persistence (PR will be linked here) to let the persistence decide on the bulk subscriptions. Aedes will also be provided with a PR containing usage of new outgoingEnqueue instead of the old one removing `parallel` as discussed in https://github.com/mcollina/aedes-cached-persistence/issues/5 

2. outgoingEnqueue will store the packet once 
```
SET packet:brokerId:brokerCounter packetPayload
SET expected:brokerId:brokerCounter offlineSubsCount
``` 
and for each client subscription:
```
RPUSH outgoing:clientId packet:brokerId:brokerCounter
```

3. OutgoingUpdate is using an in-memory mapping of `messageId -> packet key` and won't touch persistence for QOS=1, but for QOS=2 it will update client's offline packet list with `pubrel`.

4. outgoingClearMessageId will fetch original packet, remove it's index from client's offline list, decrement `expected:brokerId:brokerCounter offlineSubsCount` and if it counts zero, it also removes the original packet.

5. Only relaxation added to abstract persistence tests is:
`qos=1 packets streamed from outgoingStream won't contain any messageId` and that won't hurt.
(PR link on aedes-persistence)

This way, we are not setting a clone of original packet for each client, and that's easy to handle QOS=1 with minimal overhead. for QOS=2 we are storing a `pubrel` for each client.

- This has helped a wildcard publish to a subcription list of a million clients to reduce from 63 seconds (switching parallel with fastq in current implementation) to 30 seconds (this PR implementation)

- Redis memory greatly reduces for wildcard publishes (since we are not going to re-save the same packet for all the subscribers) and is now tons more scalable.

- QOS=1 delivery flow (forward-puback) is touching Redis less

- I haven't tested performance of QOS=2 delivery, however it should be better comparing redis commands used between PR and current.